### PR TITLE
Add sitemap listing

### DIFF
--- a/src/app/api/analyze-robots/route.ts
+++ b/src/app/api/analyze-robots/route.ts
@@ -63,7 +63,7 @@ function analyzeRobotsTxt(content: string): string {
     
     if (!trimmedLine.includes(':')) continue;
     
-    const [directive, value] = trimmedLine.split(':').map(part => part.trim().toLowerCase());
+    const [directive, value] = trimmedLine.replace(':','|').split('|').map(part => part.trim().toLowerCase());
     
     switch(directive) {
       case 'user-agent':
@@ -86,7 +86,7 @@ function analyzeRobotsTxt(content: string): string {
 
   // Generate human-readable analysis
   Object.entries(rules).forEach(([agent, ruleSet], index) => {
-    analysis.push(`\n\nAgent rules ${index + 1}: ${agent}`);
+    analysis.push(`\n\nAgent rules ${index + 1}: ${agent} - `);
     
     if (ruleSet.disallow.length) {
       analysis.push('Blocked from crawling:');
@@ -104,7 +104,10 @@ function analyzeRobotsTxt(content: string): string {
   });
 
   if (sitemaps.length) {
-    analysis.push(`\n\nSitemaps declared: ${sitemaps.join(', ')}`);
+    analysis.push(`\n\nSitemaps declared:`);
+    analysis.push('PATHS_START')
+    sitemaps.forEach(path => analysis.push(path));
+    analysis.push('PATHS_END');
   }
 
   return analysis.join('\n');


### PR DESCRIPTION
This PR updates the robots.txt analyzer page with the following changes:

-  **Improved Formatting:** The formatting of the titles has been updated to make it more _presentable_
**Old formatting**
![formatting-before](https://github.com/user-attachments/assets/e81d3b85-89ad-4142-818c-00d845be6e36)
**New formatting**
![formatting-after](https://github.com/user-attachments/assets/9b239154-5e73-4212-a66c-7573524f2232)

- **Sitemap Links Handling**: The sitemap links have been truncated to display only the protocol of the URL. To address this, I implemented a _not-so-elegant_ solution to send the complete sitemap link to the client. This allows the frontend to list the complete sitemap links alongside other paths.
**Truncated sitemaps**
![sitemaps-before](https://github.com/user-attachments/assets/4ac37b01-7d26-46e4-9961-7df3f6cd4109)
**Sitemaps listings**
![sitemaps-after](https://github.com/user-attachments/assets/49e0679d-aed6-4552-b9cd-956ce2fb8266)

I welcome any suggestions for a more elegant approach. I look forward to your feedback

